### PR TITLE
feat: add supabase service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@react-navigation/bottom-tabs": "^7.3.10",
         "@react-navigation/elements": "^2.3.8",
         "@react-navigation/native": "^7.1.6",
+        "@supabase/supabase-js": "^2.53.0",
         "babel-plugin-module-resolver": "^5.0.2",
         "expo": "~53.0.20",
         "expo-blur": "~14.1.5",
@@ -3737,6 +3738,81 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.71.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.71.1.tgz",
+      "integrity": "sha512-mMIQHBRc+SKpZFRB2qtupuzulaUhFYupNyxqDj5Jp/LyPvcWvjaJzZzObv6URtL/O6lPxkanASnotGtNpS3H2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.4.5.tgz",
+      "integrity": "sha512-v5GSqb9zbosquTo6gBwIiq7W9eQ7rE5QazsK/ezNiQXdCbY+bH8D9qEaBIkhVvX4ZRW5rP03gEfw5yw9tiq4EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/node-fetch": {
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "1.19.4",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.19.4.tgz",
+      "integrity": "sha512-O4soKqKtZIW3olqmbXXbKugUtByD2jPa8kL2m2c1oozAO11uCcGrRhkZL0kVxjBLrXHE0mdSkFsMj7jDSfyNpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.11.15",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.11.15.tgz",
+      "integrity": "sha512-HQKRnwAqdVqJW/P9TjKVK+/ETpW4yQ8tyDPPtRMKOH4Uh3vQD74vmj353CYs8+YwVBKubeUOOEpI9CT8mT4obw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.13",
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "isows": "^1.0.7",
+        "ws": "^8.18.2"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.10.4",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.10.4.tgz",
+      "integrity": "sha512-cvL02GarJVFcNoWe36VBybQqTVRq6wQSOCvTS64C+eyuxOruFIm1utZAY0xi2qKtHJO3EjKaj8iWJKySusDmAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.53.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.53.0.tgz",
+      "integrity": "sha512-Vg9sl0oFn55cCPaEOsDsRDbxOVccxRrK/cikjL1XbywHEOfyA5SOOEypidMvQLwgoAfnC2S4D9BQwJDcZs7/TQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.71.1",
+        "@supabase/functions-js": "2.4.5",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "1.19.4",
+        "@supabase/realtime-js": "2.11.15",
+        "@supabase/storage-js": "^2.10.4"
+      }
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.17",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
@@ -3866,6 +3942,12 @@
         "undici-types": "~7.8.0"
       }
     },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
       "version": "19.0.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.14.tgz",
@@ -3893,6 +3975,15 @@
       "resolved": "https://registry.npmjs.org/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz",
       "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
@@ -8924,6 +9015,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isows": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
+      "integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
       }
     },
     "node_modules/istanbul-lib-coverage": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@react-navigation/bottom-tabs": "^7.3.10",
     "@react-navigation/elements": "^2.3.8",
     "@react-navigation/native": "^7.1.6",
+    "@supabase/supabase-js": "^2.53.0",
     "babel-plugin-module-resolver": "^5.0.2",
     "expo": "~53.0.20",
     "expo-blur": "~14.1.5",

--- a/services/supabaseService.ts
+++ b/services/supabaseService.ts
@@ -1,0 +1,311 @@
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { API_CONFIG } from '@/config/constants';
+import { DailyBudget, PlannedTransaction, Transaction, NewTransaction } from '@/types';
+
+// Initialize Supabase client
+const supabaseUrl = process.env.EXPO_PUBLIC_SUPABASE_URL || '';
+const supabaseKey = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY || process.env.EXPO_PUBLIC_SUPABASE_KEY || '';
+export const supabase: SupabaseClient = createClient(supabaseUrl, supabaseKey);
+
+/**
+ * Custom error class for Supabase API errors
+ */
+export class SupabaseApiError extends Error {
+  constructor(
+    message: string,
+    public status?: number,
+    public details?: any,
+  ) {
+    super(message);
+    this.name = 'SupabaseApiError';
+  }
+}
+
+/**
+ * Fetches the latest daily budget record from Supabase
+ */
+export async function fetchLatestDailyBudget(): Promise<DailyBudget> {
+  const { data, error } = await supabase
+    .from('days')
+    .select(
+      `daily_budget_left,
+       daily_spent_sum,
+       todays_variable_daily_limit,
+       auto_savigs_value,
+       auto_savings_percent,
+       auto_goals_value,
+       auto_goals_percent,
+       auto_savings_sum,
+       auto_goals_sum`
+    )
+    .order('created_at', { ascending: false })
+    .limit(1);
+
+  if (error) {
+    throw new SupabaseApiError(error.message, error.status, error);
+  }
+
+  const record = data?.[0];
+  if (!record) {
+    return {};
+  }
+
+  return {
+    dailyBudgetLeft: record.daily_budget_left?.toString(),
+    dailySpentSum: record.daily_spent_sum?.toString(),
+    todaysVariableDailyLimit: record.todays_variable_daily_limit?.toString(),
+    automaticSavingsToday: record.auto_savigs_value?.toString(),
+    automaticSavingsPercentage: record.auto_savings_percent?.toString(),
+    automaticGoalDepositsToday: record.auto_goals_value?.toString(),
+    automaticGoalDepositsPercentage: record.auto_goals_percent?.toString(),
+    automaticSavingsMonthSum: record.auto_savings_sum?.toString(),
+    automaticGoalDepositsMonthSum: record.auto_goals_sum?.toString(),
+  };
+}
+
+/**
+ * Fetches recent transactions from Supabase
+ */
+export async function fetchRecentTransactions(): Promise<Transaction[]> {
+  const { data, error } = await supabase
+    .from('transactions')
+    .select('id, Name, Ai_Category, Value, transaction_date, category_type')
+    .neq('category_type', 'Planned')
+    .order('transaction_date', { ascending: false })
+    .limit(API_CONFIG.TRANSACTIONS_LIMIT);
+
+  if (error) {
+    throw new SupabaseApiError(error.message, error.status, error);
+  }
+
+  if (!data) {
+    return [];
+  }
+
+  return data.map((record): Transaction => ({
+    id: record.id,
+    Name: record.Name || '',
+    Ai_Category: record.Ai_Category || '',
+    Value: record.Value?.toString() || '',
+    Date: record.transaction_date || '',
+  }));
+}
+
+/**
+ * Fetches planned transactions from Supabase
+ */
+export async function fetchPlannedTransactions(): Promise<PlannedTransaction[]> {
+  const { data, error } = await supabase
+    .from('goals')
+    .select('id, Name, Value, URL, Created, _NumberOfHundreds, Decision_date, Decision, Currently_selected_goal')
+    .order('Created', { ascending: false });
+
+  if (error) {
+    throw new SupabaseApiError(error.message, error.status, error);
+  }
+
+  if (!data) {
+    return [];
+  }
+
+  return data.map((record): PlannedTransaction => ({
+    id: record.id,
+    Name: record.Name || '',
+    Value: record.Value?.toString() || '',
+    URL: record.URL || '',
+    Created: record.Created || '',
+    NumberOfHundreds: record._NumberOfHundreds || 0,
+    Decision_date: record.Decision_date || '',
+    Decision: record.Decision || '',
+    Currently_selected_goal: record.Currently_selected_goal || false,
+  }));
+}
+
+/**
+ * Adds a new transaction to Supabase
+ */
+export async function addTransaction(transaction: NewTransaction): Promise<Transaction> {
+  const now = new Date().toISOString();
+
+  const insertData: any = {
+    Name: transaction.name,
+    Value: transaction.value,
+    transaction_date: transaction.date || now,
+  };
+
+  if (transaction.category) {
+    insertData.Ai_Category = transaction.category;
+  }
+  if (transaction.fromAccountId) {
+    insertData.from_account_id = transaction.fromAccountId;
+  }
+  if (transaction.toAccountId) {
+    insertData.to_account_id = transaction.toAccountId;
+  }
+
+  const { data, error } = await supabase
+    .from('transactions')
+    .insert(insertData)
+    .select('*')
+    .single();
+
+  if (error) {
+    throw new SupabaseApiError(error.message, error.status, error);
+  }
+
+  return {
+    id: data.id,
+    Name: data.Name || '',
+    Ai_Category: data.Ai_Category || '',
+    Value: data.Value?.toString() || '0',
+    Date: data.transaction_date || now,
+  };
+}
+
+/**
+ * Creates two transactions for goal savings: income on Goals account and expense on Checking account
+ */
+export async function createGoalTransaction(goalName: string, amount: number): Promise<void> {
+  const today = new Date().toISOString().split('T')[0];
+
+  const { data: goalsAccount, error: goalsError } = await supabase
+    .from('accounts')
+    .select('id')
+    .eq('Name', 'Goals')
+    .single();
+  if (goalsError) {
+    throw new SupabaseApiError(goalsError.message, goalsError.status, goalsError);
+  }
+  if (!goalsAccount) {
+    throw new SupabaseApiError('Goals account not found');
+  }
+
+  const { data: checkingAccount, error: checkingError } = await supabase
+    .from('accounts')
+    .select('id')
+    .eq('Name', 'Checking')
+    .single();
+  if (checkingError) {
+    throw new SupabaseApiError(checkingError.message, checkingError.status, checkingError);
+  }
+  if (!checkingAccount) {
+    throw new SupabaseApiError('Checking account not found');
+  }
+
+  const { error } = await supabase.from('transactions').insert({
+    Name: 'cel długoterminowy: ' + goalName,
+    Value: amount,
+    transaction_date: today,
+    to_account_id: goalsAccount.id,
+    from_account_id: checkingAccount.id,
+  });
+
+  if (error) {
+    throw new SupabaseApiError(error.message, error.status, error);
+  }
+}
+
+/**
+ * Sets a specific goal as the currently selected goal
+ */
+export async function setCurrentGoal(goalId: string): Promise<void> {
+  const { data: allGoals, error } = await supabase
+    .from('goals')
+    .select('id, Currently_selected_goal');
+
+  if (error) {
+    throw new SupabaseApiError(error.message, error.status, error);
+  }
+  if (!allGoals) {
+    throw new SupabaseApiError('No goals found');
+  }
+
+  const currentlySelected = allGoals.find(g => g.Currently_selected_goal);
+  const targetGoal = allGoals.find(g => g.id === goalId);
+
+  if (!targetGoal) {
+    throw new SupabaseApiError('Target goal not found');
+  }
+
+  const updates: Promise<any>[] = [];
+
+  if (currentlySelected && currentlySelected.id !== goalId) {
+    updates.push(
+      supabase.from('goals').update({ Currently_selected_goal: false }).eq('id', currentlySelected.id)
+    );
+  }
+
+  if (!targetGoal.Currently_selected_goal) {
+    updates.push(
+      supabase.from('goals').update({ Currently_selected_goal: true }).eq('id', goalId)
+    );
+  }
+
+  for (const p of updates) {
+    const { error: updateError } = await p;
+    if (updateError) {
+      throw new SupabaseApiError(updateError.message, updateError.status, updateError);
+    }
+  }
+}
+
+/**
+ * Realizes a goal by creating two transactions: transfer and expense
+ */
+export async function realizeGoal(goalName: string, finalPrice: number): Promise<void> {
+  const { data: goalsAccount, error: goalsError } = await supabase
+    .from('accounts')
+    .select('id')
+    .eq('Name', 'Goals')
+    .single();
+  if (goalsError) {
+    throw new SupabaseApiError(goalsError.message, goalsError.status, goalsError);
+  }
+  if (!goalsAccount) {
+    throw new SupabaseApiError('Goals account not found');
+  }
+
+  const { data: checkingAccount, error: checkingError } = await supabase
+    .from('accounts')
+    .select('id')
+    .eq('Name', 'Checking')
+    .single();
+  if (checkingError) {
+    throw new SupabaseApiError(checkingError.message, checkingError.status, checkingError);
+  }
+  if (!checkingAccount) {
+    throw new SupabaseApiError('Checking account not found');
+  }
+
+  await Promise.all([
+    addTransaction({
+      name: `Realizacja celu: ${goalName}`,
+      value: finalPrice,
+      fromAccountId: goalsAccount.id,
+      toAccountId: checkingAccount.id,
+    }),
+    addTransaction({
+      name: goalName,
+      value: finalPrice,
+    }),
+  ]);
+}
+
+/**
+ * Formats a transaction value for display
+ */
+export function formatTransactionValue(value: string): string {
+  const numericValue = parseFloat(value);
+  if (isNaN(numericValue)) {
+    return value;
+  }
+  return Math.round(numericValue).toString();
+}
+
+/**
+ * Utility function to check if a transaction value is positive (income)
+ */
+export function isPositiveTransaction(value: string): boolean {
+  const numericValue = parseFloat(value);
+  return !isNaN(numericValue) && numericValue > 0;
+}


### PR DESCRIPTION
## Summary
- add Supabase client with error handling
- implement budget, transaction, and goal helpers via Supabase
- include utility helpers for transaction formatting

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f2fc81d1c8323a2737f3071d9afa6